### PR TITLE
feat: 쿠키와 미들웨어를 활용하여 다크모드 구현

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,19 +3,23 @@ import "@/styles/globals.css";
 import { Footer } from "@/components/layout";
 import SimpleHeader from "@/components/layout/simple-header";
 import { css } from "#/styled-system/css";
+import { cookies } from "next/headers";
 
 export const metadata: Metadata = {
-  title: "별 세 개짜리 개발자 | Heojoooon.",
+  title: "Heojoooon.",
   description: "프론트엔드 개발자 허준영입니다.",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const cookieStore = await cookies();
+  const currentColorMode = cookieStore.get("color-mode")?.value || "light";
+
   return (
-    <html lang="ko">
+    <html lang="ko" data-color-mode={currentColorMode}>
       <head>
         <meta
           name="google-site-verification"

--- a/src/components/layout/mode-button.tsx
+++ b/src/components/layout/mode-button.tsx
@@ -1,30 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { motion } from "motion/react";
 import { RiMoonFill, RiQuestionMark, RiSunFill } from "react-icons/ri";
 import { css, cva, cx } from "#/styled-system/css";
+import { useIsMounted } from "@/hooks/use-is-mounted";
+import { useColorMode } from "@/hooks/use-color-mode";
 
 export const ModeButton = () => {
-  const [isMounted, setIsMounted] = useState(false);
-  const [isDark, setIsDark] = useState<boolean>(false);
+  const isMounted = useIsMounted();
+  const { colorMode, toggleColorMode } = useColorMode();
 
   const handleClickButton = () => {
-    setIsDark((prev) => !prev);
+    toggleColorMode();
   };
-
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
-
-  useEffect(() => {
-    const root = document.documentElement;
-    if (isDark) {
-      root.setAttribute("data-color-mode", "dark");
-    } else {
-      root.setAttribute("data-color-mode", "light");
-    }
-  }, [isDark]);
 
   if (!isMounted)
     return (
@@ -35,10 +23,7 @@ export const ModeButton = () => {
 
   return (
     <motion.button
-      className={cx(
-        layoutStyle,
-        buttonRecipe({ theme: isDark ? "dark" : "light" })
-      )}
+      className={cx(layoutStyle, buttonRecipe({ theme: colorMode }))}
       type="button"
       onClick={handleClickButton}
       whileTap={{ scale: 0.95, rotate: 25 }}
@@ -50,7 +35,7 @@ export const ModeButton = () => {
         rotate: 360,
       }}
     >
-      {isDark ? (
+      {colorMode === "dark" ? (
         <RiMoonFill size={22} color="#FFE400" />
       ) : (
         <RiSunFill size={22} color="#FF0000" />

--- a/src/hooks/use-color-mode.ts
+++ b/src/hooks/use-color-mode.ts
@@ -1,0 +1,28 @@
+import { useLayoutEffect, useState } from "react";
+
+export const COLOR_MODES = ["light", "dark"] as const;
+export type ColorModeType = (typeof COLOR_MODES)[number];
+
+export const useColorMode = () => {
+  const [colorMode, setColorMode] = useState<ColorModeType>("light");
+
+  const toggleColorMode = () => {
+    const nextMode = colorMode === "dark" ? "light" : "dark";
+    document.cookie = `color-mode=${nextMode}`;
+    setColorMode(nextMode);
+  };
+
+  useLayoutEffect(() => {
+    const currentMode = getColorModeFromCookie() || "light";
+    setColorMode(currentMode as ColorModeType);
+    const root = document.documentElement;
+    root.setAttribute("data-color-mode", colorMode);
+  }, [colorMode]);
+
+  return { colorMode, toggleColorMode };
+};
+
+function getColorModeFromCookie(): string | undefined {
+  const match = document.cookie.match(/(?:^|;\s*)color-mode=([^;]*)/);
+  return match ? decodeURIComponent(match[1]) : undefined;
+}

--- a/src/hooks/use-is-mounted.ts
+++ b/src/hooks/use-is-mounted.ts
@@ -1,0 +1,15 @@
+import { useState, useEffect } from "react";
+
+export const useIsMounted = () => {
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+
+    return () => {
+      setIsMounted(false);
+    };
+  }, []);
+
+  return isMounted;
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  // NOTE: 쿠키에 'theme' 속성이 없다면 기본값으로 'light' 모드 설정
+  const response = NextResponse.next();
+  const theme = request.cookies.get("color-mode");
+
+  if (!theme) {
+    response.cookies.set("color-mode", "light");
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: "/:path*", // 모든 경로
+};


### PR DESCRIPTION
- 미들웨어를 통해 요청 시 색상 모드 정보를 가진 쿠키 확인
  - 쿠키가 없다면 첫 요청이므로 기본 모드인 라이트 모드 설정
  - 쿠키가 있다면 설정된 쿠키 값을 그대로 응답에 포함
- `app/layout.tsx` 에서 쿠키 값을 확인하고 해당되는 색상 모드를 html의 `data-color-mode` 속성으로 추가
  - 해당 속성으로 PandaCSS config를 통해 다크모드 적용