### PR TITLE
fix: 다크모드 시 Giscus 테마가 변경되지 않는 문제 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Footer } from "@/components/layout";
 import SimpleHeader from "@/components/layout/simple-header";
 import { css } from "#/styled-system/css";
 import { cookies } from "next/headers";
+import { ColorModeProvider, ColorModeType } from "@/contexts/color-mode";
 
 export const metadata: Metadata = {
   title: "Heojoooon.",
@@ -16,7 +17,8 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   const cookieStore = await cookies();
-  const currentColorMode = cookieStore.get("color-mode")?.value || "light";
+  const currentColorMode = (cookieStore.get("color-mode")?.value ||
+    "light") as ColorModeType;
 
   return (
     <html lang="ko" data-color-mode={currentColorMode}>
@@ -32,11 +34,13 @@ export default async function RootLayout({
       </head>
 
       <body className={bodyStyle}>
-        <SimpleHeader />
+        <ColorModeProvider initialMode={currentColorMode}>
+          <SimpleHeader />
 
-        {children}
+          {children}
 
-        <Footer />
+          <Footer />
+        </ColorModeProvider>
       </body>
     </html>
   );

--- a/src/components/post/giscus.tsx
+++ b/src/components/post/giscus.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { css } from "#/styled-system/css";
+import { useColorMode } from "@/hooks/use-color-mode";
 import { useEffect, useRef } from "react";
 
 export const Giscus = () => {
   const ref = useRef<HTMLDivElement>(null);
-  const theme = "catppuccin_latte";
+  const { colorMode } = useColorMode();
 
   useEffect(() => {
     if (!ref.current || ref.current.hasChildNodes()) return;
@@ -22,20 +23,29 @@ export const Giscus = () => {
     scriptElem.setAttribute("data-reactions-enabled", "1");
     scriptElem.setAttribute("data-emit-metadata", "0");
     scriptElem.setAttribute("data-input-position", "bottom");
-    scriptElem.setAttribute("data-theme", theme);
+    scriptElem.setAttribute(
+      "data-theme",
+      colorMode === "light" ? "noborder_light" : "noborder_dark"
+    );
     scriptElem.setAttribute("data-lang", "ko");
     ref.current.appendChild(scriptElem);
-  }, []);
+  }, [colorMode]);
 
   useEffect(() => {
     const iframe = document.querySelector<HTMLIFrameElement>(
       "iframe.giscus-frame"
     );
     iframe?.contentWindow?.postMessage(
-      { giscus: { setConfig: { theme } } },
+      {
+        giscus: {
+          setConfig: {
+            theme: colorMode === "light" ? "noborder_light" : "noborder_dark",
+          },
+        },
+      },
       "https://giscus.app"
     );
-  }, [theme]);
+  }, [colorMode]);
 
   return <section className={containerStyle} ref={ref} />;
 };

--- a/src/contexts/color-mode.tsx
+++ b/src/contexts/color-mode.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { createContext, useLayoutEffect, useState } from "react";
+
+export const COLOR_MODES = ["light", "dark"] as const;
+export type ColorModeType = (typeof COLOR_MODES)[number];
+
+interface ColorModeContextProps {
+  colorMode: ColorModeType;
+  toggleColorMode: () => void;
+}
+
+export const ColorModeContext = createContext<
+  ColorModeContextProps | undefined
+>(undefined);
+
+interface ColorModeProviderProps {
+  children: React.ReactNode;
+  initialMode?: ColorModeType;
+}
+
+export const ColorModeProvider = ({
+  children,
+  initialMode,
+}: ColorModeProviderProps) => {
+  const [colorMode, setColorMode] = useState<ColorModeType>(
+    initialMode || "light"
+  );
+
+  const toggleColorMode = () => {
+    const next = colorMode === "light" ? "dark" : "light";
+    setColorMode(next);
+    document.cookie = `color-mode=${next};`;
+    document.documentElement.setAttribute("data-color-mode", next);
+  };
+
+  useLayoutEffect(() => {
+    if (initialMode) {
+      document.documentElement.setAttribute("data-color-mode", initialMode);
+      return;
+    }
+
+    const match = document.cookie.match(/(?:^|;\s*)color-mode=([^;]*)/);
+    const mode = (match?.[1] === "dark" ? "dark" : "light") as ColorModeType;
+    setColorMode(mode);
+    document.documentElement.setAttribute("data-color-mode", mode);
+  }, [initialMode]);
+
+  return (
+    <ColorModeContext.Provider value={{ colorMode, toggleColorMode }}>
+      {children}
+    </ColorModeContext.Provider>
+  );
+};

--- a/src/hooks/use-color-mode.ts
+++ b/src/hooks/use-color-mode.ts
@@ -1,35 +1,45 @@
-import { useLayoutEffect, useState } from "react";
+// import { useLayoutEffect, useState } from "react";
 
-export const COLOR_MODES = ["light", "dark"] as const;
-export type ColorModeType = (typeof COLOR_MODES)[number];
+import { ColorModeContext } from "@/contexts/color-mode";
+import { useContext } from "react";
+
+// export const COLOR_MODES = ["light", "dark"] as const;
+// export type ColorModeType = (typeof COLOR_MODES)[number];
+
+// export const useColorMode = () => {
+//   const [colorMode, setColorMode] = useState<ColorModeType>("light");
+
+//   const toggleColorMode = () => {
+//     const nextMode = colorMode === "dark" ? "light" : "dark";
+//     if (typeof document !== "undefined") {
+//       document.cookie = `color-mode=${nextMode}`;
+//     }
+//     setColorMode(nextMode);
+//   };
+
+//   useLayoutEffect(() => {
+//     const currentMode = getColorModeFromCookie() || "light";
+//     setColorMode(currentMode as ColorModeType);
+//   }, []);
+
+//   useLayoutEffect(() => {
+//     if (typeof document !== "undefined") {
+//       document.documentElement.setAttribute("data-color-mode", colorMode);
+//     }
+//   }, [colorMode]);
+
+//   return { colorMode, toggleColorMode };
+// };
+
+// function getColorModeFromCookie(): string | undefined {
+//   if (typeof document === "undefined") return undefined;
+//   const match = document.cookie.match(/(?:^|;\s*)color-mode=([^;]*)/);
+//   return match ? decodeURIComponent(match[1]) : undefined;
+// }
 
 export const useColorMode = () => {
-  const [colorMode, setColorMode] = useState<ColorModeType>("light");
-
-  const toggleColorMode = () => {
-    const nextMode = colorMode === "dark" ? "light" : "dark";
-    if (typeof document !== "undefined") {
-      document.cookie = `color-mode=${nextMode}`;
-    }
-    setColorMode(nextMode);
-  };
-
-  useLayoutEffect(() => {
-    const currentMode = getColorModeFromCookie() || "light";
-    setColorMode(currentMode as ColorModeType);
-  }, []);
-
-  useLayoutEffect(() => {
-    if (typeof document !== "undefined") {
-      document.documentElement.setAttribute("data-color-mode", colorMode);
-    }
-  }, [colorMode]);
-
-  return { colorMode, toggleColorMode };
+  const context = useContext(ColorModeContext);
+  if (!context)
+    throw new Error("useColorMode must be used within a ColorModeProvider");
+  return context;
 };
-
-function getColorModeFromCookie(): string | undefined {
-  if (typeof document === "undefined") return undefined;
-  const match = document.cookie.match(/(?:^|;\s*)color-mode=([^;]*)/);
-  return match ? decodeURIComponent(match[1]) : undefined;
-}


### PR DESCRIPTION
- 지역 상태를 훅으로 제공하고 있어 ColorMode가 변경되더라도 상태 변화를 감지하지 못함.
  - 따라서 Giscus 테마가 변경되지 않았음.
  - 이를 Context API를 통해 ColorMode를 저장하여 해결.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a color mode context, allowing the app to manage and toggle between light and dark modes.
  - The color mode preference is now persisted and synchronized across the app, including the Giscus comment widget, which updates its theme in real time.

- **Refactor**
  - Updated the color mode hook to use context for state management, simplifying color mode access throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->