### PR TITLE
fix: 뷰포트에 들어오는 이미지만 로드하도록 설정 추가 및 Link prefetch 설정

### DIFF
--- a/src/components/mdx-components/image.tsx
+++ b/src/components/mdx-components/image.tsx
@@ -16,6 +16,8 @@ export const MDXImage = ({ src, alt, ...rest }: ImageProps) => {
         height={400}
         className={imageStyle}
         unoptimized={isUnoptimized}
+        loading="lazy"
+        quality={85}
         {...rest}
       />
       {alt !== "" && match ? (

--- a/src/components/post-list/list-item.tsx
+++ b/src/components/post-list/list-item.tsx
@@ -20,7 +20,7 @@ export const PostListItem = ({
   const displayDate = updatedAt ? `${updatedAt} (updated)` : createdAt;
 
   return (
-    <Link href={`/${slug}`} className={containerStyle}>
+    <Link href={`/${slug}`} className={containerStyle} prefetch={true}>
       <div className={cx(coverImageWrawpperStyle, coverImageStyle)}>
         <Image
           className={coverImageStyle}
@@ -28,7 +28,8 @@ export const PostListItem = ({
           alt={`"${title}" 커버 이미지`}
           width={180}
           height={180}
-          priority
+          loading="lazy"
+          quality={75}
         />
       </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Images now load lazily across the site, improving page load performance.
  - Linked pages in post lists are now prefetched for faster navigation.

- **Style**
  - Adjusted image quality settings for a better balance between visual fidelity and loading speed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->